### PR TITLE
"Best practices"

### DIFF
--- a/branches/version5/scripts/votes.pl
+++ b/branches/version5/scripts/votes.pl
@@ -3,11 +3,14 @@
 
 use DBI;
 
+use strict;
+use warnings;
+
 my $id = shift;
 
 $id =~ s/[^0-9]//g;
 
-$sql = "select user_login, vote_date, vote_value from users, votes where vote_type='links' and vote_link_id = $id and user_id=vote_user_id order by vote_date asc";
+my $sql = "select user_login, vote_date, vote_value from users, votes where vote_type='links' and vote_link_id = $id and user_id=vote_user_id order by vote_date asc";
 
 
 my $dbh = DBI->connect ('DBI:mysql:meneame', 'meneame', '');


### PR DESCRIPTION
Sé que es un poco académico, pero es buena costumbre poner siempre use strict y warnings. 
También sé que esto es para uso interno, pero la regexp que usas para que se usen sólo decimales podría saltarse quizás con Unicode... No lo sé, pero es mejor extraer en vez de borrar.
