### PR TITLE
Updated behavior of social buttons in header.html

### DIFF
--- a/branches/version5/www/templates/header.html
+++ b/branches/version5/www/templates/header.html
@@ -184,9 +184,17 @@
   <div class="edname">
 	{% if this_site_properties.facebook_page %}
 		<a href="{{ this_site_properties.facebook_page }}" title="{% trans _('síguenos en Facebook') %}" ><img class="semiopaque" src="{{globals.base_static}}img/external/fb-24.png" width="24" height="24" alt="Facebook"/></a>
-	{% endif %}
+	{% else %}
+		{% if globals.facebook_page && this_site.owner == 0 %}
+			<a href="{{ globals.facebook_page }}" title="{% trans _('síguenos en Facebook') %}" ><img class="semiopaque" src="{{globals.base_static}}img/external/fb-24.png" width="24" height="24" alt="Facebook"/></a>
+		{% endif %}
+	{% endif %}	
 	{% if this_site_properties.twitter_page %}
 		<a href="{{ this_site_properties.twitter_page }}" title="{% trans _('síguenos en Twitter') %}" ><img class="semiopaque" src="{{globals.base_static}}img/external/tw-24.png" width="24" height="24" alt="Twitter"/></a>
+	{% else %}
+		{% if globals.twitter_page && this_site.owner == 0 %}
+			<a href="{{ globals.twitter_page }}" title="{% trans _('síguenos en Twitter') %}" ><img class="semiopaque" src="{{globals.base_static}}img/external/tw-24.png" width="24" height="24" alt="Twitter"/></a>
+		{% endif %}
 	{% endif %}
   </div>
 


### PR DESCRIPTION
If the sub has not preferences, and exists globals.twitter_page and the owner id equals 0, it will appear web default social buttons set in config.php. The same for facebook.

It could be useful in order to don't have to create preferences for the default subs.
