### PR TITLE
Problema en cabecera

### DIFF
--- a/branches/version5/www/comment.php
+++ b/branches/version5/www/comment.php
@@ -53,7 +53,7 @@ if (! $comment->hide_comment) {
 	}
 	$title = text_to_summary($comment->content, 120);
 } else {
-	$title = '';
+	$title = 'Comentario | Menéame';
 }
 
 // Canonical url


### PR DESCRIPTION
Al estar la cabecera en blanco si un comentario está oculto (muchos negativos), en Google Chrome aparece su URL. Se trata de poner un texto cualquiera para estos casos.
Ejemplo:
https://www.meneame.net/c/15857113
