### PR TITLE
Envío solo por parte del responsable del sub

### DIFF
--- a/branches/version5/www/libs/html1.php
+++ b/branches/version5/www/libs/html1.php
@@ -113,7 +113,7 @@ function do_header($title, $id='home', $options = false) {
 
 	if (! is_array($options)) {
 		$left_options = array();
-		if ($this_site->enabled && empty($this_site_properties['new_disabled'])) {
+		if ($this_site->enabled && empty($this_site_properties['new_disabled']) || $current_user->user_id == $this_site->owner ) {
 			$left_options[] = new MenuOption(_('enviar historia'), $globals['base_url'].'submit', $id, _('enviar nueva historia'));
 		}
 		$left_options[] = new MenuOption(_('portada'), $globals['base_url'], $id, _('página principal'));

--- a/branches/version5/www/submit.php
+++ b/branches/version5/www/submit.php
@@ -17,7 +17,10 @@ force_authentication();
 
 $site = SitesMgr::get_info();
 $site_properties = SitesMgr::get_extended_properties();
-if (! $site->enabled || ! empty($site_properties['new_disabled'])) die;
+$new_disabled = false;
+if (! empty($site_properties['new_disabled']) && $current_user->user_id != $site->owner) $new_disabled = true;
+if (! $site->enabled || $new_disabled ) die;
+
 
 global $errors;
 $errors = array();


### PR DESCRIPTION
Con esto se matarían dos pájaros de un tiro, además de deshabilitar el envío, se permite que el *owner* pueda seguir enviando. Si algún usuario quiere mantener el sub él solo, no tiene que andar habilitando y deshabilitando.