### PR TITLE
List of privates readable when creating a new one

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -981,6 +981,7 @@ function priv_new(user_id) {
 			historyManager.pop('#priv_new');
 		},
 		overlayClose: false,
+		opacity: 0.5,
 		transition: 'none',
 		title: false,
 		scrolling: true,


### PR DESCRIPTION
Reduce the opacity of the overlay to make it possible to read previous privates when creating a new one.