### PR TITLE
Added a double check to avoid duplicated answers on latency problems

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -1127,6 +1127,10 @@ function show_answers(type, id) {
 	answers = $('#answers-'+id);
 	if (answers.length == 0) {
 		$.get(base_url + 'backend/'+program, { "type": type, "id": id }, function (html) {
+			var current_answers = $('#answers-'+id);
+			if (current_answers.length != 0) {
+				return;
+			}
 			element = $(dom_id).parent().parent();
 			element.append('<div class="comment-answers" id="answers-'+id+'">'+html+'</div>');
 			element.trigger('DOMChanged', element);


### PR DESCRIPTION
If you request several times the answers to a comment under high latency conditions, the answers are appended by duplicate.

This is an example how it looks; you can reproduce it throttling the network in Chrome DevTools.

![image](https://cloud.githubusercontent.com/assets/16188556/21473127/9b933380-cafb-11e6-89c1-93339c747d5c.png)

My patch just applies a double check on _success_ function to assert other request did not do yet its job before appending the response.