### PR TITLE
Fixed line break of search form

### DIFF
--- a/www/css/es/mnm.css
+++ b/www/css/es/mnm.css
@@ -329,7 +329,7 @@ float:left;
 height:auto;
 margin: 10px 10px 0 0;
 position:relative;
-float:right;
+display: inline-block;
 }
 
 .searchform .searchbox {

--- a/www/css/mnm.css
+++ b/www/css/mnm.css
@@ -338,7 +338,7 @@ font-size: 110%;
 height:auto;
 margin: 10px 10px 0 0;
 position:relative;
-float:right;
+display: inline-block;
 }
 
 .searchform .searchbox {


### PR DESCRIPTION
This pull request fixes issue #104:

> Al darle a la lupa del buscador y mostrarse el cuadro de texto para introducir la búsqueda, desplaza hacia arriba el resto de la cabecera, pero el alto lo deja igual, de forma que queda inaccesible y bastante mal.

I tested it in the following browsers:

- Mozilla Firefox 43.0.2
- Google Chrome 55.0.2883.95
- Safari 10.0.1
- Internet Explorer 11.0.9600.18282